### PR TITLE
Copy comments from Maven example

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,11 @@ apply plugin: 'no.tornado.fxlauncher'
 
 fxlauncher {
     applicationVendor 'My Company'
+    // Base URL where you will host the application artifacts
     applicationUrl 'http://fxldemo.tornado.no/'
     applicationMainClass 'no.tornado.FxlDemo'
     acceptDowngrade false
+    // Optional scp target for application artifacts hosted at the above url
     deployTarget 'w48839@fxldemo.tornado.no:fxldemo'
 }
 


### PR DESCRIPTION
In the Maven example project, there are some comments explaining a few of the attributes. I've copied a few of those over here to make the Gradle example project just as clear.